### PR TITLE
Add skill level calculation for user stats

### DIFF
--- a/greek-conjugator/backend/app/routes/verbs.py
+++ b/greek-conjugator/backend/app/routes/verbs.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request, session
 from ..models import db, Verb, Conjugation, UserProgress, PracticeSession
 from .auth import login_required
 from ..services.greek_text import GreekTextProcessor, compare_greek_texts
+from ..services.skill import calculate_skill_level
 from datetime import datetime, timedelta
 import random
 
@@ -254,6 +255,7 @@ def get_user_stats():
         total_correct = db.session.query(db.func.sum(UserProgress.correct_attempts)).filter_by(user_id=user_id).scalar() or 0
         
         accuracy_rate = (total_correct / total_attempts * 100) if total_attempts > 0 else 0
+        skill_level = calculate_skill_level(total_correct, accuracy_rate)
         
         # Get recent sessions
         recent_sessions = PracticeSession.query.filter_by(user_id=user_id).order_by(PracticeSession.created_at.desc()).limit(10).all()
@@ -270,6 +272,7 @@ def get_user_stats():
             'total_attempts': total_attempts,
             'total_correct': total_correct,
             'accuracy_rate': round(accuracy_rate, 2),
+            'skill_level': skill_level,
             'due_cards': due_cards,
             'recent_sessions': [session.to_dict() for session in recent_sessions]
         })

--- a/greek-conjugator/backend/app/services/skill.py
+++ b/greek-conjugator/backend/app/services/skill.py
@@ -1,0 +1,23 @@
+"""Utility functions for estimating user skill level."""
+
+def calculate_skill_level(total_correct: int, accuracy_rate: float) -> int:
+    """Estimate a user's skill level based on progress.
+
+    Parameters
+    ----------
+    total_correct: int
+        Total number of correct answers the user has given.
+    accuracy_rate: float
+        Overall accuracy percentage (0-100).
+
+    Returns
+    -------
+    int
+        Skill level from 1 (beginner) to 10 (expert).
+    """
+    # Experience grows with correct answers; accuracy provides a bonus.
+    experience = total_correct // 10
+    accuracy_bonus = int(accuracy_rate // 20)
+    level = experience + accuracy_bonus + 1
+    return max(1, min(level, 10))
+

--- a/greek-conjugator/backend/requirements.txt
+++ b/greek-conjugator/backend/requirements.txt
@@ -4,3 +4,4 @@ Flask-CORS==4.0.0
 Flask-Session==0.5.0
 Werkzeug==2.3.7
 python-dotenv==1.0.0
+requests==2.31.0

--- a/greek-conjugator/backend/test_skill.py
+++ b/greek-conjugator/backend/test_skill.py
@@ -1,0 +1,10 @@
+from app.services.skill import calculate_skill_level
+
+
+def test_calculate_skill_level_progression():
+    assert calculate_skill_level(0, 0) == 1
+    beginner = calculate_skill_level(10, 50)
+    advanced = calculate_skill_level(100, 80)
+    assert beginner >= 1
+    assert advanced > beginner
+


### PR DESCRIPTION
## Summary
- compute a simple skill level from user progress and expose it in the stats endpoint
- provide reusable `calculate_skill_level` utility
- document dependency on `requests` and test skill level logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ff2b5e048322878117334ee5579a